### PR TITLE
adds local postgres db and updates .envexample file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ POSTGRES_PASSWORD=""
 POSTGRES_HOST=""
 POSTGRES_PORT=""
 DATABASE_NAME=""
+DATABASE_URL= "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${DATABASE_NAME}"
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,15 @@
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
-DATABASE_URL="file:./db.sqlite"
+# DATABASE_URL="file:./db.sqlite"
+
+# Internal Postrgres DB
+# Creating these fields will automatically generate the DATABASE_URL in the docker-compose.yml file
+POSTGRES_USER=""
+POSTGRES_PASSWORD=""
+POSTGRES_HOST=""
+POSTGRES_PORT=""
+DATABASE_NAME=""
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,13 @@ services:
   db:
     image: postgres
     restart: always
-    environment:
-      POSTGRES_PASSWORD: example
-
+    env_file:
+      - .env
+      
   adminer:
     image: adminer
     restart: always
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${DATABASE_NAME}
     ports:
       - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,5 @@ services:
   adminer:
     image: adminer
     restart: always
-    environment:
-      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${DATABASE_NAME}
     ports:
       - 8080:8080


### PR DESCRIPTION
you can add your own credentials to create the postgres db in the .env something like this. 

POSTGRES_USER="grindylocks"
POSTGRES_PASSWORD="grindylocks"
POSTGRES_HOST="localhost"
POSTGRES_PORT="5432"
DATABASE_NAME="grindylocks-db"

The DATABASE_URL file will make itself once you add these 